### PR TITLE
Remove extra copies from encodeCString

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -19,7 +19,7 @@ export function checkFDBErr(code: number) {
 }
 
 export function encodeCString(string: string) {
-  return new Uint8Array([...new TextEncoder().encode(string), 0]);
+  return new TextEncoder().encode(`${string}\0`);
 }
 
 export class PointerContainer {


### PR DESCRIPTION
This optimises the encodeCString method by handling null byte addition on JavaScript side instead of doing two extra copies: First for copying the `encode()` calls resulting `Uint8Array` into a JS `Array` with the zero value added at the end, and then another copy copying that array's contents into a new `Uint8Array`.