### PR TITLE
Replace PointerContainer with UnsafePointerView

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -1,4 +1,3 @@
-import { assertNotEquals } from "./deps.ts";
 import { lib } from "./lib.ts";
 
 export class FDBError extends Error {
@@ -22,17 +21,21 @@ export function encodeCString(string: string) {
   return new Uint8Array([...new TextEncoder().encode(string), 0]);
 }
 
-export class PointerContainer {
-  constructor(public array = new BigUint64Array(1)) {
+export class PointerContainer extends Deno.UnafePointerView {
+  constructor(array = new BigUint64Array(1)) {
+    const pointer = Deno.UnsafePointer.of(array)!;
+    super(pointer);
   }
 
   use() {
-    return Deno.UnsafePointer.of(this.array);
+    return this.pointer;
   }
 
   get() {
-    const pointer = Deno.UnsafePointer.create(this.array[0]);
-    assertNotEquals(pointer, null);
-    return pointer!;
+    const pointer = this.getPointer(0);
+    if (pointer === null) {
+      throw new Error("Unexpectedly found null pointer in PointerContainer");
+    }
+    return pointer;
   }
 }


### PR DESCRIPTION
Draft of a somewhat simplified `PointerContainer`:
1. Starting with Deno 1.31.2 (if memory serves), `Deno.UnsafePointer.of()`'s returned pointer object will keep the TypedArray alive for as long as the pointer object lives (this uses a `WeakMap` underneath the hood). This means that we do not need to manually keep the `array` in place.
2. `Deno.UnsafePointerView.getPointer()` method can be used to read a pointer through a pointer, ie. the same thing you're doing here but with the `Deno.UnsafePointer.create()` method.

Frankly, the `PointerContainer` type might not even serve enough of a purpose to exist. It might be better to simply use an `UnsafeDataView` in the places where it is needed.

It might also be better to use a `Uint8Array` to get tighter control on the amount of memory allocated.

However, this draft does not include all the other changes that would be needed to make this completely work.