### PR TITLE
Fix memory leak in Future constructor

### DIFF
--- a/future.ts
+++ b/future.ts
@@ -1,20 +1,30 @@
 import { lib } from "./lib.ts";
 import { checkFDBErr, PointerContainer } from "./utils.ts";
 
+const FUTURE_CB_MAP = new Map<number | bigint, Future>();
+const FUTURE_CALLBACK = new Deno.UnsafeCallback(
+  { parameters: ["pointer", "pointer"], result: "void" },
+  (pointer) => {
+    if (!pointer) {
+      return;
+    }
+    const pointerValue = Deno.UnsafePointer.value(pointer)
+    const future = FUTURE_CB_MAP.get(pointerValue);
+    if (future) {
+      FUTURE_CB_MAP.delete(pointerValue);
+      future.callback?.(future);
+    }
+  },
+);
+
 export class Future {
   private callback?: (future: Future) => void;
 
   constructor(private pointer: NonNullable<Deno.PointerValue>) {
+    FUTURE_CB_MAP.set(Deno.UnsafePointer.value(this.pointer), this);
     checkFDBErr(lib.fdb_future_set_callback(
       this.pointer,
-      new Deno.UnsafeCallback(
-        { parameters: ["pointer", "pointer"], result: "void" },
-        (pointer) => {
-          if (pointer) {
-            this.callback?.(this);
-          }
-        },
-      ).pointer,
+      FUTURE_CALLBACK.pointer,
       null,
     ));
   }


### PR DESCRIPTION
The `Deno.UnsafeCallback` objects are not garbage collected: Since their foremost point is to setup a C function pointer that can be passed to C and then may or may not call back later at theoretically any time, there is no way to know from Deno side if the pointer is still needed or not.

As a result, creating callbacks repeatedly without making sure they're also closed causes a memory leak.

This PR fixes the leak in the `Future` constructor by moving the callback into a "static". Incoming callbacks find their intended Deno side `Future` instances through a `Map<number | bigint, Future>` and delete their own instance from the Map once found.

Note by the way that FoundationDB says that `fdb_future_set_callback` may call the callback synchronously, and it will never call the callback twice. This means that in this code:
```ts
const future = new Future(futurePointer);
future.setCallback(() => console.log("Ready"));
```
the C callback may get called before `new Future` returns and thus before the `setCallback` JS call is made, leading to `"Ready"` never being logged.